### PR TITLE
solves #3

### DIFF
--- a/node_modules/url-status-code/LICENSE
+++ b/node_modules/url-status-code/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Geir Gåsodden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/node_modules/url-status-code/README.md
+++ b/node_modules/url-status-code/README.md
@@ -1,0 +1,53 @@
+[![Build Status](https://travis-ci.org/zrrrzzt/url-status-code.svg?branch=master)](https://travis-ci.org/zrrrzzt/url-status-code)
+[![Coverage Status](https://coveralls.io/repos/zrrrzzt/url-status-code/badge.svg?branch=master&service=github)](https://coveralls.io/github/zrrrzzt/url-status-code?branch=master)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)
+
+# url-status-code
+
+Get status code for url.
+
+## Installation
+
+From npm
+
+```sh
+$ npm i url-status-code
+```
+
+## Usage
+
+```JavaScript
+(async () => {
+  const urlStatusCode = require('url-status-code')
+  const url = 'https://www.npmjs.com'
+  try {
+    const status = await urlStatusCode(url)
+    console.log(status)
+  } catch (error) {
+    console.error(error)
+  }
+})()
+//=> 200
+```
+
+or you can use callback
+
+```JavaScript
+
+const urlStatusCode = require('url-status-code')
+const url = 'https://www.npmjs.com'
+
+urlStatusCode(url, (error, statusCode) => {
+  if (error) {
+    console.error(error)
+  } else {
+    console.log(statusCode)
+  }
+})
+
+// => 200
+```
+
+## License
+
+[MIT](LICENSE)

--- a/node_modules/url-status-code/index.js
+++ b/node_modules/url-status-code/index.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const checkUrlStatus = require('./lib/check-url-status')
+
+module.exports = (url, callback) => {
+  return new Promise((resolve, reject) => {
+    checkUrlStatus(url, (error, statusCode) => {
+      if (error) {
+        return callback ? callback(error, null) : reject(error)
+      } else {
+        return callback ? callback(null, statusCode) : resolve(statusCode)
+      }
+    })
+  })
+}

--- a/node_modules/url-status-code/lib/check-url-status.js
+++ b/node_modules/url-status-code/lib/check-url-status.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const validUrl = require('valid-url')
+const { name, version } = require('../package.json')
+const validStart = require('./valid-start')
+
+module.exports = (uri, callback) => {
+  if (!uri) {
+    return callback(new Error('Missing required input: uri'), null)
+  }
+
+  if (!validUrl.isWebUri(uri)) {
+    return callback(new Error('Supplied uri is not valid'), null)
+  }
+
+  if (!validStart(uri)) {
+    return callback(new Error('Supplied uri is not valid'), null)
+  }
+
+  const protocol = /https/.test(uri) ? 'https' : 'http'
+  const http = require(protocol)
+  const options = new URL(uri)
+
+  options.agent = false
+  options.headers = {
+    'User-Agent': `${name}/${version}`,
+    Accept: '*/*'
+  }
+
+  http.get(options, response => {
+    return callback(null, response.statusCode)
+  }).on('error', error => callback(error))
+}

--- a/node_modules/url-status-code/lib/valid-start.js
+++ b/node_modules/url-status-code/lib/valid-start.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = url => {
+  var valid = true
+
+  if (url.startsWith('http://https://')) {
+    valid = false
+  }
+
+  if (url.startsWith('https://http://')) {
+    valid = false
+  }
+
+  return valid
+}

--- a/node_modules/url-status-code/package.json
+++ b/node_modules/url-status-code/package.json
@@ -1,0 +1,75 @@
+{
+  "_from": "url-status-code",
+  "_id": "url-status-code@2.0.0",
+  "_inBundle": false,
+  "_integrity": "sha512-ODpSV5o2OM/tldo6sq5BGl6ILQ0htv+1LSv66qQI94vG2quKMpfxYp2XDGSI0sR9CXZaLJpQ74xMGLiIkQXJzQ==",
+  "_location": "/url-status-code",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "url-status-code",
+    "name": "url-status-code",
+    "escapedName": "url-status-code",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/url-status-code/-/url-status-code-2.0.0.tgz",
+  "_shasum": "332ee1fabcb73f55321c8e7754e5a17825902367",
+  "_spec": "url-status-code",
+  "_where": "/home/tushar/desktops/d10/4anime-scraper",
+  "author": {
+    "name": "Geir Gåsodden",
+    "email": "geir.gasodden@pythonia.no",
+    "url": "https://github.com/zrrrzzt"
+  },
+  "bugs": {
+    "url": "https://github.com/zrrrzzt/url-status-code/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "valid-url": "1.0.9"
+  },
+  "deprecated": false,
+  "description": "Get status code for url",
+  "devDependencies": {
+    "ava": "3.6.0",
+    "coveralls": "3.0.11",
+    "nyc": "15.0.1",
+    "standard": "14.3.3"
+  },
+  "engines": {
+    "node": ">=12.16.2"
+  },
+  "files": [
+    "lib/",
+    "index.js"
+  ],
+  "homepage": "https://github.com/zrrrzzt/url-status-code#readme",
+  "keywords": [
+    "url",
+    "status",
+    "http"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "url-status-code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zrrrzzt/url-status-code.git"
+  },
+  "scripts": {
+    "coverage": "nyc ava",
+    "coveralls": "nyc ava && nyc report --reporter=lcov && cat coverage/lcov.info | coveralls",
+    "refresh": "rm -rf node_modules && rm package-lock.json && npm install",
+    "standard-fix": "standard --fix",
+    "test": "standard && ava",
+    "test-offline": "standard && ava"
+  },
+  "version": "2.0.0"
+}

--- a/node_modules/valid-url/.jshintrc
+++ b/node_modules/valid-url/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "node" : true,
+  "undef": true,
+  "unused": true,
+  "indent": 4
+}

--- a/node_modules/valid-url/.travis.yml
+++ b/node_modules/valid-url/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "0.6"
+  - "0.8"
+  - "0.10"

--- a/node_modules/valid-url/LICENSE
+++ b/node_modules/valid-url/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2013 Odysseas Tsatalos and oDesk Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/valid-url/Makefile
+++ b/node_modules/valid-url/Makefile
@@ -1,0 +1,10 @@
+TAP=node_modules/.bin/tap
+LINT=node_modules/.bin/jshint
+
+test:   lint
+	$(TAP) test/*.js
+
+lint:
+	$(LINT) index.js
+	$(LINT) test/*.js
+  

--- a/node_modules/valid-url/README.md
+++ b/node_modules/valid-url/README.md
@@ -1,0 +1,134 @@
+URI validation functions
+==
+[![Build Status](https://travis-ci.org/ogt/valid-url.png)](https://travis-ci.org/ogt/valid-url)
+
+## Synopsis
+
+Common url validation methods 
+```
+    var validUrl = require('valid-url');
+  
+    if (validUrl.isUri(suspect)){
+        console.log('Looks like an URI');
+    } else {
+        console.log('Not a URI');
+    }
+```
+
+Replicates the functionality of Richard Sonnen <sonnen@richardsonnen.com> perl module :
+http://search.cpan.org/~sonnen/Data-Validate-URI-0.01/lib/Data/Validate/URI.pm [full code here](http://anonscm.debian.org/gitweb/?p=users/dom/libdata-validate-uri-perl.git)
+into a nodejs module. Translated practically line by line from perl. 
+It passes all the original tests.
+
+## Description
+
+(copied from original perl module)
+
+> This module collects common URI validation routines to make input validation, and untainting easier and more readable.
+> All functions return an untainted value if the test passes, and undef if it fails. This means that you should always check for a defined status explicitly. Don't assume the return will be true.
+> The value to test is always the first (and often only) argument.
+> There are a number of other URI validation modules out there as well (see below.) This one focuses on being fast, lightweight, and relatively 'real-world'. i.e. it's good if you want to check user input, and don't need to parse out the URI/URL into chunks.
+> Right now the module focuses on HTTP URIs, since they're arguably the most common. If you have a specialized scheme you'd like to have supported, let me know.
+
+## Installation 
+
+```
+    npm install valid-url
+```
+
+## Methods
+```javascript
+/*
+ * @Function isUri(value)
+ *
+ * @Synopsis  is the value a well-formed uri?
+ * @Description  
+        Returns the untainted URI if the test value appears to be well-formed.  Note that
+        you may really want one of the more practical methods like is_http_uri or is_https_uri,
+        since the URI standard (RFC 3986) allows a lot of things you probably don't want.
+ * @Arguments 
+ *   value  The potential URI to test.
+ *
+ * @Returns The untainted RFC 3986 URI on success, undefined on failure.
+ * @Notes 
+        This function does not make any attempt to check whether the URI is accessible
+        or 'makes sense' in any meaningful way.  It just checks that it is formatted
+        correctly.
+ *
+ */
+
+
+/*
+ * @Function isHttpUri(value)
+ * @Synopsis   is the value a well-formed HTTP uri?
+ * @Description  
+        Specialized version of isUri() that only likes http:// urls.  As a result, it can
+        also do a much more thorough job validating.  Also, unlike isUri() it is more
+        concerned with only allowing real-world URIs through.  Things like relative
+        hostnames are allowed by the standards, but probably aren't wise.  Conversely,
+        null paths aren't allowed per RFC 2616 (should be '/' instead), but are allowed
+        by this function.
+        
+        This function only works for fully-qualified URIs.  /bob.html won't work.  
+        See RFC 3986 for the appropriate method to turn a relative URI into an absolute 
+        one given its context.
+        
+        Returns the untainted URI if the test value appears to be well-formed.
+        
+        Note that you probably want to either call this in combo with is_https_uri(). i.e.
+        
+        if(isHttpUri(uri) || isHttpsUri(uri)) console.log('Good');
+        
+        or use the convenience method isWebUri which is equivalent.
+
+ * @Arguments 
+ *   value  The potential URI to test.
+ *
+ * @Returns The untainted RFC 3986 URI on success, undefined on failure.
+ * @Notes 
+        This function does not make any attempt to check whether the URI is accessible
+        or 'makes sense' in any meaningful way.  It just checks that it is formatted
+        correctly.
+ */
+ 
+
+
+/*
+ * @Function isHttpsUri(value)
+ * @Synopsis   is the value a well-formed HTTPS uri?
+ * @Description  
+        See is_http_uri() for details.  This version only likes the https URI scheme.
+        Otherwise it's identical to is_http_uri()
+ * @Arguments 
+ *   value  The potential URI to test.
+ *
+ * @Returns The untainted RFC 3986 URI on success, undefined on failure.
+ * @Notes 
+        This function does not make any attempt to check whether the URI is accessible
+        or 'makes sense' in any meaningful way.  It just checks that it is formatted
+        correctly.
+ */
+ 
+ 
+ /*
+ * @Function isWebUri(value)
+ * @Synopsis   is the value a well-formed HTTP or HTTPS uri?
+ * @Description  
+        This is just a convenience method that combines isHttpUri and isHttpsUri
+        to accept most common real-world URLs.
+ * @Arguments 
+ *   value  The potential URI to test.
+ *
+ * @Returns The untainted RFC 3986 URI on success, undefined on failure.
+ * @Notes 
+        This function does not make any attempt to check whether the URI is accessible
+        or 'makes sense' in any meaningful way.  It just checks that it is formatted
+        correctly.
+ */
+ 
+```
+
+## See also 
+
+RFC 3986, RFC 3966, RFC 4694, RFC 4759, RFC 4904
+

--- a/node_modules/valid-url/index.js
+++ b/node_modules/valid-url/index.js
@@ -1,0 +1,153 @@
+(function(module) {
+    'use strict';
+
+    module.exports.is_uri = is_iri;
+    module.exports.is_http_uri = is_http_iri;
+    module.exports.is_https_uri = is_https_iri;
+    module.exports.is_web_uri = is_web_iri;
+    // Create aliases
+    module.exports.isUri = is_iri;
+    module.exports.isHttpUri = is_http_iri;
+    module.exports.isHttpsUri = is_https_iri;
+    module.exports.isWebUri = is_web_iri;
+
+
+    // private function
+    // internal URI spitter method - direct from RFC 3986
+    var splitUri = function(uri) {
+        var splitted = uri.match(/(?:([^:\/?#]+):)?(?:\/\/([^\/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?/);
+        return splitted;
+    };
+
+    function is_iri(value) {
+        if (!value) {
+            return;
+        }
+
+        // check for illegal characters
+        if (/[^a-z0-9\:\/\?\#\[\]\@\!\$\&\'\(\)\*\+\,\;\=\.\-\_\~\%]/i.test(value)) return;
+
+        // check for hex escapes that aren't complete
+        if (/%[^0-9a-f]/i.test(value)) return;
+        if (/%[0-9a-f](:?[^0-9a-f]|$)/i.test(value)) return;
+
+        var splitted = [];
+        var scheme = '';
+        var authority = '';
+        var path = '';
+        var query = '';
+        var fragment = '';
+        var out = '';
+
+        // from RFC 3986
+        splitted = splitUri(value);
+        scheme = splitted[1]; 
+        authority = splitted[2];
+        path = splitted[3];
+        query = splitted[4];
+        fragment = splitted[5];
+
+        // scheme and path are required, though the path can be empty
+        if (!(scheme && scheme.length && path.length >= 0)) return;
+
+        // if authority is present, the path must be empty or begin with a /
+        if (authority && authority.length) {
+            if (!(path.length === 0 || /^\//.test(path))) return;
+        } else {
+            // if authority is not present, the path must not start with //
+            if (/^\/\//.test(path)) return;
+        }
+
+        // scheme must begin with a letter, then consist of letters, digits, +, ., or -
+        if (!/^[a-z][a-z0-9\+\-\.]*$/.test(scheme.toLowerCase()))  return;
+
+        // re-assemble the URL per section 5.3 in RFC 3986
+        out += scheme + ':';
+        if (authority && authority.length) {
+            out += '//' + authority;
+        }
+
+        out += path;
+
+        if (query && query.length) {
+            out += '?' + query;
+        }
+
+        if (fragment && fragment.length) {
+            out += '#' + fragment;
+        }
+
+        return out;
+    }
+
+    function is_http_iri(value, allowHttps) {
+        if (!is_iri(value)) {
+            return;
+        }
+
+        var splitted = [];
+        var scheme = '';
+        var authority = '';
+        var path = '';
+        var port = '';
+        var query = '';
+        var fragment = '';
+        var out = '';
+
+        // from RFC 3986
+        splitted = splitUri(value);
+        scheme = splitted[1]; 
+        authority = splitted[2];
+        path = splitted[3];
+        query = splitted[4];
+        fragment = splitted[5];
+
+        if (!scheme)  return;
+
+        if(allowHttps) {
+            if (scheme.toLowerCase() != 'https') return;
+        } else {
+            if (scheme.toLowerCase() != 'http') return;
+        }
+
+        // fully-qualified URIs must have an authority section that is
+        // a valid host
+        if (!authority) {
+            return;
+        }
+
+        // enable port component
+        if (/:(\d+)$/.test(authority)) {
+            port = authority.match(/:(\d+)$/)[0];
+            authority = authority.replace(/:\d+$/, '');
+        }
+
+        out += scheme + ':';
+        out += '//' + authority;
+        
+        if (port) {
+            out += port;
+        }
+        
+        out += path;
+        
+        if(query && query.length){
+            out += '?' + query;
+        }
+
+        if(fragment && fragment.length){
+            out += '#' + fragment;
+        }
+        
+        return out;
+    }
+
+    function is_https_iri(value) {
+        return is_http_iri(value, true);
+    }
+
+    function is_web_iri(value) {
+        return (is_http_iri(value) || is_https_iri(value));
+    }
+
+})(module);

--- a/node_modules/valid-url/package.json
+++ b/node_modules/valid-url/package.json
@@ -1,0 +1,53 @@
+{
+  "_from": "valid-url@1.0.9",
+  "_id": "valid-url@1.0.9",
+  "_inBundle": false,
+  "_integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+  "_location": "/valid-url",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "valid-url@1.0.9",
+    "name": "valid-url",
+    "escapedName": "valid-url",
+    "rawSpec": "1.0.9",
+    "saveSpec": null,
+    "fetchSpec": "1.0.9"
+  },
+  "_requiredBy": [
+    "/url-status-code"
+  ],
+  "_resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+  "_shasum": "1c14479b40f1397a75782f115e4086447433a200",
+  "_spec": "valid-url@1.0.9",
+  "_where": "/home/tushar/desktops/d10/4anime-scraper/node_modules/url-status-code",
+  "bugs": {
+    "url": "https://github.com/ogt/valid-url/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {},
+  "deprecated": false,
+  "description": "URI validation functions",
+  "devDependencies": {
+    "jshint": "~2.1.4",
+    "tap": "~0.4.3"
+  },
+  "homepage": "https://github.com/ogt/valid-url#readme",
+  "keywords": [
+    "url",
+    "validation",
+    "check",
+    "checker",
+    "pattern"
+  ],
+  "main": "index.js",
+  "name": "valid-url",
+  "repository": {
+    "url": "git://github.com/ogt/valid-url.git"
+  },
+  "scripts": {
+    "test": "make test"
+  },
+  "version": "1.0.9"
+}

--- a/node_modules/valid-url/test/is_http_uri.js
+++ b/node_modules/valid-url/test/is_http_uri.js
@@ -1,0 +1,22 @@
+var test = require("tap").test,
+    is_http_uri = require('../').is_http_uri;
+
+test("testing is_http_uri", function (t) {
+
+    // valid
+    t.ok(is_http_uri('http://www.richardsonnen.com/'), 'http://www.richardsonnen.com/');
+    t.ok(is_http_uri('http://www.richardsonnen.com'), 'http://www.richardsonnen.com');
+    t.ok(is_http_uri('http://www.richardsonnen.com/foo/bar/test.html'), 'http://www.richardsonnen.com/foo/bar/test.html');
+    t.ok(is_http_uri('http://www.richardsonnen.com/?foo=bar'), 'http://www.richardsonnen.com/?foo=bar');
+    t.ok(is_http_uri('http://www.richardsonnen.com:8080/test.html'), 'http://www.richardsonnen.com:8080/test.html');
+    t.ok(is_http_uri('http://example.w3.org/path%20with%20spaces.html'), 'http://example.w3.org/path%20with%20spaces.html');
+    t.ok(is_http_uri('http://192.168.0.1/'), 'http://192.168.0.1/');
+
+    // invalid
+    t.notOk(is_http_uri(''), "bad: ''");
+    t.notOk(is_http_uri('ftp://ftp.richardsonnen.com'), "bad: 'ftp://ftp.richardsonnen.com'");
+    t.notOk(is_http_uri('http:www.richardsonnen.com'), "bad: 'http:www.richardsonnen.com'");
+    t.notOk(is_http_uri('https://www.richardsonnen.com'), "bad: 'https://www.richardsonnen.com'");
+
+    t.end();
+});

--- a/node_modules/valid-url/test/is_https_uri.js
+++ b/node_modules/valid-url/test/is_https_uri.js
@@ -1,0 +1,22 @@
+var test = require("tap").test,
+    is_https_uri = require('../').is_https_uri;
+
+test("testing is_https_uri", function (t) {
+
+    // valid
+    t.ok(is_https_uri('https://www.richardsonnen.com/'), 'https://www.richardsonnen.com/');
+    t.ok(is_https_uri('https://www.richardsonnen.com'), 'https://www.richardsonnen.com');
+    t.ok(is_https_uri('https://www.richardsonnen.com/foo/bar/test.html'), 'https://www.richardsonnen.com/foo/bar/test.html');
+    t.ok(is_https_uri('https://www.richardsonnen.com/?foo=bar'), 'https://www.richardsonnen.com/?foo=bar');
+    t.ok(is_https_uri('https://www.richardsonnen.com:8080/test.html'), 'https://www.richardsonnen.com:8080/test.html');
+    t.ok(is_https_uri('https://example.w3.org/path%20with%20spaces.html'), 'http://example.w3.org/path%20with%20spaces.html');
+    t.ok(is_https_uri('https://192.168.0.1/'), 'http://192.168.0.1/');
+
+    // invalid
+    t.notOk(is_https_uri(''), "bad: ''");
+    t.notOk(is_https_uri('http://www.richardsonnen.com/'), 'http://www.richardsonnen.com/');
+    t.notOk(is_https_uri('ftp://ftp.richardsonnen.com'), "bad: 'ftp://ftp.richardsonnen.com'");
+    t.notOk(is_https_uri('https:www.richardsonnen.com'), "bad: 'https:www.richardsonnen.com'");
+
+    t.end();
+});

--- a/node_modules/valid-url/test/is_uri.js
+++ b/node_modules/valid-url/test/is_uri.js
@@ -1,0 +1,35 @@
+var test = require("tap").test,
+    is_uri = require('../').is_uri;
+
+test("testing is_uri", function (t) {
+
+    // valid -  from RFC 3986 for the most part
+    t.ok(is_uri('http://localhost/'), 'http://localhost/');
+    t.ok(is_uri('http://example.w3.org/path%20with%20spaces.html'), 'http://example.w3.org/path%20with%20spaces.html');
+    t.ok(is_uri('http://example.w3.org/%20'), 'http://example.w3.org/%20');
+    t.ok(is_uri('ftp://ftp.is.co.za/rfc/rfc1808.txt'), 'ftp://ftp.is.co.za/rfc/rfc1808.txt');
+    t.ok(is_uri('ftp://ftp.is.co.za/../../../rfc/rfc1808.txt'), 'ftp://ftp.is.co.za/../../../rfc/rfc1808.txt');
+    t.ok(is_uri('http://www.ietf.org/rfc/rfc2396.txt'), 'http://www.ietf.org/rfc/rfc2396.txt');
+    t.ok(is_uri('ldap://[2001:db8::7]/c=GB?objectClass?one'), 'ldap://[2001:db8::7]/c=GB?objectClass?one');
+    t.ok(is_uri('mailto:John.Doe@example.com'), 'mailto:John.Doe@example.com');
+    t.ok(is_uri('news:comp.infosystems.www.servers.unix'), 'news:comp.infosystems.www.servers.unix');
+    t.ok(is_uri('tel:+1-816-555-1212'), 'tel:+1-816-555-1212');
+    t.ok(is_uri('telnet://192.0.2.16:80/'), 'telnet://192.0.2.16:80/');
+    t.ok(is_uri('urn:oasis:names:specification:docbook:dtd:xml:4.1.2'), 'urn:oasis:names:specification:docbook:dtd:xml:4.1.2');
+
+
+    // invalid
+    t.notOk(is_uri(''), "bad: ''");
+    t.notOk(is_uri('foo'), 'bad: foo');
+    t.notOk(is_uri('foo@bar'), 'bad: foo@bar');
+    t.notOk(is_uri('http://<foo>'), 'bad: http://<foo>'); // illegal characters
+    t.notOk(is_uri('://bob/'), 'bad: ://bob/'); // empty schema
+    t.notOk(is_uri('1http://bob'), 'bad: 1http://bob/'); // bad schema
+    t.notOk(is_uri('1http:////foo.html'), 'bad: 1http://bob/'); // bad path
+    t.notOk(is_uri('http://example.w3.org/%illegal.html'), 'http://example.w3.org/%illegal.html');
+    t.notOk(is_uri('http://example.w3.org/%a'), 'http://example.w3.org/%a'); // partial escape
+    t.notOk(is_uri('http://example.w3.org/%a/foo'), 'http://example.w3.org/%a/foo'); // partial escape
+    t.notOk(is_uri('http://example.w3.org/%at'), 'http://example.w3.org/%at'); // partial escape
+
+    t.end();
+});

--- a/node_modules/valid-url/test/is_web_uri.js
+++ b/node_modules/valid-url/test/is_web_uri.js
@@ -1,0 +1,28 @@
+var test = require("tap").test,
+    is_web_uri = require('../').is_web_uri;
+
+test("testing is_web_uri", function (t) {
+
+    // valid
+    t.ok(is_web_uri('https://www.richardsonnen.com/'), 'https://www.richardsonnen.com/');
+    t.ok(is_web_uri('https://www.richardsonnen.com'), 'https://www.richardsonnen.com');
+    t.ok(is_web_uri('https://www.richardsonnen.com/foo/bar/test.html'), 'https://www.richardsonnen.com/foo/bar/test.html');
+    t.ok(is_web_uri('https://www.richardsonnen.com/?foo=bar'), 'https://www.richardsonnen.com/?foo=bar');
+    t.ok(is_web_uri('https://www.richardsonnen.com:8080/test.html'), 'https://www.richardsonnen.com:8080/test.html');
+    t.ok(is_web_uri('http://www.richardsonnen.com/'), 'http://www.richardsonnen.com/');
+    t.ok(is_web_uri('http://www.richardsonnen.com'), 'http://www.richardsonnen.com');
+    t.ok(is_web_uri('http://www.richardsonnen.com/foo/bar/test.html'), 'http://www.richardsonnen.com/foo/bar/test.html');
+    t.ok(is_web_uri('http://www.richardsonnen.com/?foo=bar'), 'http://www.richardsonnen.com/?foo=bar');
+    t.ok(is_web_uri('http://www.richardsonnen.com:8080/test.html'), 'http://www.richardsonnen.com:8080/test.html');
+    t.ok(is_web_uri('http://example.w3.org/path%20with%20spaces.html'), 'http://example.w3.org/path%20with%20spaces.html');
+    t.ok(is_web_uri('http://192.168.0.1/'), 'http://192.168.0.1/');
+
+    // invalid
+    t.ok(!is_web_uri(''), "bad: ''");
+    t.ok(!is_web_uri('ftp://ftp.richardsonnen.com'), "bad: 'ftp://ftp.richardsonnen.com'");
+    t.ok(!is_web_uri('https:www.richardsonnen.com'), "bad: 'http:www.richardsonnen.com'");
+    t.ok(!is_web_uri('http:www.richardsonnen.com'), "bad: 'http:www.richardsonnen.com'");
+
+
+    t.end();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "twist-scraper",
-  "version": "1.0.0",
+  "name": "4anime-scraper",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1128,10 +1128,23 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "url-status-code": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/url-status-code/-/url-status-code-2.0.0.tgz",
+      "integrity": "sha512-ODpSV5o2OM/tldo6sq5BGl6ILQ0htv+1LSv66qQI94vG2quKMpfxYp2XDGSI0sR9CXZaLJpQ74xMGLiIkQXJzQ==",
+      "requires": {
+        "valid-url": "1.0.9"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "widest-line": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "homepage": "https://github.com/tarunm20/4anime-scraper#readme",
   "dependencies": {
     "axios": "^0.19.2",
-    "cheerio": "^1.0.0-rc.3"
+    "cheerio": "^1.0.0-rc.3",
+    "url-status-code": "^2.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.4"


### PR DESCRIPTION
- dropping `id` parameter from episode urls changes md5 hash, which can bypass `403` errors in some cases
- `getVideoLinkFromUrl` returns gcs links if uri status is `403`
(this probably wont work in the future)
